### PR TITLE
Make post_meta partial template use safeHTML

### DIFF
--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -13,5 +13,5 @@
 {{- end }}
 
 {{- with ($scratch.Get "meta") }}
-{{- delimit . "&nbsp;·&nbsp;" -}}
+{{- delimit . "&nbsp;·&nbsp;" | safeHTML -}}
 {{- end -}}


### PR DESCRIPTION
The post_meta template has to use safeHTML in order to correctly return HTML tags without escaping them.