### PR TITLE
Fix buttons spacing errors in the cookie banner.

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -309,6 +309,10 @@ a[role='button'],
   right: 3%;
   max-width: 400px;
   opacity: 0.9;
+  footer {
+    display: flex;
+    justify-content: space-between;
+  }
 }
 
 @keyframes hover {


### PR DESCRIPTION
This patch ensures correct spacing between cookie banner buttons.

The weird thing is that on the link from the CI and also on the stock demo website this patch is not required, but if I deploy the demo locally or to my gihtub.io website it is.